### PR TITLE
Hotfix: Mobile/Tablet Node selector

### DIFF
--- a/src/components/dialogue/NodeConnectionModal.jsx
+++ b/src/components/dialogue/NodeConnectionModal.jsx
@@ -1,91 +1,80 @@
 import { useState } from 'react';
-import { Link2, MessageCircle, User, CornerUpLeft, CheckCircle2, Clock, ExternalLink } from 'lucide-react';
 import {
 	Drawer,
 	DrawerContent,
 	DrawerHeader,
 	DrawerTitle,
 	DrawerDescription,
+	DrawerFooter,
 } from '@/components/ui/drawer';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { NativeSelect } from '@/components/ui/native-select';
 import { getNodeDefinition } from '@/config/dialogueNodes';
-
-const iconMap = {
-	messageCircle: MessageCircle,
-	user: User,
-	cornerUpLeft: CornerUpLeft,
-	checkCircle2: CheckCircle2,
-	clock: Clock,
-	externalLink: ExternalLink,
-};
 
 /**
  * Node Connection Modal Component
  * Allows mobile users to connect a placeholder's parent node to an already-existing node.
+ * Uses a Vaul bottom-drawer with a NativeSelect for node selection.
  */
 export function NodeConnectionModal({ open, onOpenChange, candidateNodes, onSelectNode }) {
-	const [search, setSearch] = useState('');
+	const [selectedId, setSelectedId] = useState('');
 
 	const handleOpenChange = (v) => {
 		onOpenChange(v);
-		if (!v) setSearch('');
+		if (!v) setSelectedId('');
 	};
 
-	const filtered = (candidateNodes || []).filter((n) =>
-		(n.data?.displayName || '').toLowerCase().includes(search.toLowerCase())
-	);
+	const handleConnect = () => {
+		if (!selectedId) return;
+		onSelectNode(selectedId);
+		handleOpenChange(false);
+	};
+
+	const nodes = candidateNodes || [];
 
 	return (
 		<Drawer open={open} onOpenChange={handleOpenChange}>
-			<DrawerContent>
-				<DrawerHeader>
+			<DrawerContent className="max-h-[92vh] flex flex-col">
+				<DrawerHeader className="text-left">
 					<DrawerTitle>Connect to Existing Node</DrawerTitle>
 					<DrawerDescription>Select a node to connect to</DrawerDescription>
 				</DrawerHeader>
-				<div className="px-4 pb-2">
-					<Input
-						placeholder="Search nodes..."
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						className="mb-3"
-					/>
-					<div className="flex flex-col gap-2 overflow-y-auto max-h-[50vh] pb-4">
-						{filtered.length === 0 ? (
-							<p className="text-sm text-muted-foreground text-center py-6">
-								No connectable nodes
-							</p>
-						) : (
-							filtered.map((n) => {
+
+				<div className="no-scrollbar flex-1 min-h-0 overflow-y-auto px-4 py-2">
+					{nodes.length === 0 ? (
+						<p className="text-sm text-muted-foreground text-center py-6">
+							No connectable nodes available
+						</p>
+					) : (
+						<NativeSelect
+							value={selectedId}
+							onChange={(e) => setSelectedId(e.target.value)}
+						>
+							<option value="" disabled>
+								Choose a node…
+							</option>
+							{nodes.map((n) => {
 								const def = getNodeDefinition(n.type) || {};
-								const Icon = iconMap[def.icon] || Link2;
+								const displayName = n.data?.displayName || def.label || n.id;
+								const typeLabel = def.label && def.label !== displayName ? ` (${def.label})` : '';
 								return (
-									<Button
-										key={n.id}
-										variant="outline"
-										className="h-auto p-4 justify-start gap-4"
-										onClick={() => {
-											onSelectNode(n.id);
-											handleOpenChange(false);
-										}}
-									>
-										<div
-											className={`w-10 h-10 rounded-lg bg-muted flex items-center justify-center ${def.colorClass || ''}`}
-										>
-											<Icon className="h-5 w-5" />
-										</div>
-										<div className="flex flex-col items-start gap-0.5 text-left">
-											<span className="font-semibold">
-												{n.data?.displayName || def.label}
-											</span>
-											<span className="text-xs text-muted-foreground">{def.label}</span>
-										</div>
-									</Button>
+									<option key={n.id} value={n.id}>
+										{displayName}{typeLabel}
+									</option>
 								);
-							})
-						)}
-					</div>
+							})}
+						</NativeSelect>
+					)}
 				</div>
+
+				<DrawerFooter className="border-t border-border/60 bg-background">
+					<Button onClick={handleConnect} disabled={!selectedId || nodes.length === 0}>
+						Connect
+					</Button>
+					<Button variant="ghost" onClick={() => handleOpenChange(false)}>
+						Cancel
+					</Button>
+				</DrawerFooter>
 			</DrawerContent>
 		</Drawer>
 	);

--- a/src/components/dialogue/NodeConnectionModal.jsx
+++ b/src/components/dialogue/NodeConnectionModal.jsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { Link2, MessageCircle, User, CornerUpLeft, CheckCircle2, Clock, ExternalLink } from 'lucide-react';
+import {
+	Drawer,
+	DrawerContent,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerDescription,
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { getNodeDefinition } from '@/config/dialogueNodes';
+
+const iconMap = {
+	messageCircle: MessageCircle,
+	user: User,
+	cornerUpLeft: CornerUpLeft,
+	checkCircle2: CheckCircle2,
+	clock: Clock,
+	externalLink: ExternalLink,
+};
+
+/**
+ * Node Connection Modal Component
+ * Allows mobile users to connect a placeholder's parent node to an already-existing node.
+ */
+export function NodeConnectionModal({ open, onOpenChange, candidateNodes, onSelectNode }) {
+	const [search, setSearch] = useState('');
+
+	const handleOpenChange = (v) => {
+		onOpenChange(v);
+		if (!v) setSearch('');
+	};
+
+	const filtered = (candidateNodes || []).filter((n) =>
+		(n.data?.displayName || '').toLowerCase().includes(search.toLowerCase())
+	);
+
+	return (
+		<Drawer open={open} onOpenChange={handleOpenChange}>
+			<DrawerContent>
+				<DrawerHeader>
+					<DrawerTitle>Connect to Existing Node</DrawerTitle>
+					<DrawerDescription>Select a node to connect to</DrawerDescription>
+				</DrawerHeader>
+				<div className="px-4 pb-2">
+					<Input
+						placeholder="Search nodes..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className="mb-3"
+					/>
+					<div className="flex flex-col gap-2 overflow-y-auto max-h-[50vh] pb-4">
+						{filtered.length === 0 ? (
+							<p className="text-sm text-muted-foreground text-center py-6">
+								No connectable nodes
+							</p>
+						) : (
+							filtered.map((n) => {
+								const def = getNodeDefinition(n.type) || {};
+								const Icon = iconMap[def.icon] || Link2;
+								return (
+									<Button
+										key={n.id}
+										variant="outline"
+										className="h-auto p-4 justify-start gap-4"
+										onClick={() => {
+											onSelectNode(n.id);
+											handleOpenChange(false);
+										}}
+									>
+										<div
+											className={`w-10 h-10 rounded-lg bg-muted flex items-center justify-center ${def.colorClass || ''}`}
+										>
+											<Icon className="h-5 w-5" />
+										</div>
+										<div className="flex flex-col items-start gap-0.5 text-left">
+											<span className="font-semibold">
+												{n.data?.displayName || def.label}
+											</span>
+											<span className="text-xs text-muted-foreground">{def.label}</span>
+										</div>
+									</Button>
+								);
+							})
+						)}
+					</div>
+				</div>
+			</DrawerContent>
+		</Drawer>
+	);
+}

--- a/src/components/dialogue/NodeTypeSelectionModal.jsx
+++ b/src/components/dialogue/NodeTypeSelectionModal.jsx
@@ -1,17 +1,19 @@
 import { MessageCircle, User, CornerUpLeft, CheckCircle2, Clock, ExternalLink, Link2 } from 'lucide-react';
 import {
-	Dialog,
-	DialogContent,
-	DialogHeader,
-	DialogTitle,
-	DialogDescription,
-} from '@/components/ui/dialog';
+	Drawer,
+	DrawerContent,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerDescription,
+	DrawerFooter,
+} from '@/components/ui/drawer';
 import { Button } from '@/components/ui/button';
 import { getCreatableNodeDefinitions } from '@/config/dialogueNodes';
 
 /**
  * Node Type Selection Modal Component
- * Allows mobile users to select which type of node to create
+ * Allows mobile users to select which type of node to create.
+ * Uses a bottom Drawer so the list is never clipped on small screens.
  */
 export function NodeTypeSelectionModal({ open, onOpenChange, onSelectType, onConnectExisting }) {
 	const iconMap = {
@@ -31,57 +33,71 @@ export function NodeTypeSelectionModal({ open, onOpenChange, onSelectType, onCon
 	};
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-md">
-				<DialogHeader>
-					<DialogTitle>Select Node Type</DialogTitle>
-					<DialogDescription>
+		<Drawer open={open} onOpenChange={onOpenChange}>
+			<DrawerContent className="max-h-[92vh] flex flex-col">
+				{/* Static header */}
+				<DrawerHeader className="text-left">
+					<DrawerTitle>Select Node Type</DrawerTitle>
+					<DrawerDescription>
 						Choose the type of node you want to add to the dialogue
-					</DialogDescription>
-				</DialogHeader>
-				<div className="grid gap-2 py-4">
-					{nodeTypes.map((nodeType) => {
-						const Icon = iconMap[nodeType.icon];
-						return (
-							<Button
-								key={nodeType.type}
-								variant="outline"
-								className="h-auto p-4 justify-start gap-4"
-								onClick={() => handleSelect(nodeType.type)}
-							>
-								<div className={`w-10 h-10 rounded-lg bg-muted flex items-center justify-center ${nodeType.colorClass || ''}`}>
-									{Icon ? <Icon className="h-5 w-5" /> : null}
-								</div>
-								<div className="flex flex-col items-start gap-1 text-left">
-									<span className="font-semibold">{nodeType.label}</span>
-									<span className="text-xs text-muted-foreground">
-										{nodeType.description}
-									</span>
-								</div>
-							</Button>
-						);
-					})}
-				<div className="border-t border-border my-1" />
-				<Button
-					variant="outline"
-					className="h-auto p-4 justify-start gap-4"
-					onClick={() => {
-						onOpenChange(false);
-						onConnectExisting?.();
-					}}
-				>
-					<div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center text-muted-foreground">
-						<Link2 className="h-5 w-5" />
+					</DrawerDescription>
+				</DrawerHeader>
+
+				{/* Scrollable body */}
+				<div className="no-scrollbar flex-1 min-h-0 overflow-y-auto px-4">
+					<div className="grid gap-2 pb-2">
+						{nodeTypes.map((nodeType) => {
+							const Icon = iconMap[nodeType.icon];
+							return (
+								<Button
+									key={nodeType.type}
+									variant="outline"
+									className="h-auto p-4 justify-start gap-4"
+									onClick={() => handleSelect(nodeType.type)}
+								>
+									<div className={`w-10 h-10 rounded-lg bg-muted flex items-center justify-center ${nodeType.colorClass || ''}`}>
+										{Icon ? <Icon className="h-5 w-5" /> : null}
+									</div>
+									<div className="flex flex-col items-start gap-1 text-left">
+										<span className="font-semibold">{nodeType.label}</span>
+										<span className="text-xs text-muted-foreground">
+											{nodeType.description}
+										</span>
+									</div>
+								</Button>
+							);
+						})}
+
+						<div className="border-t border-border my-1" />
+
+						<Button
+							variant="outline"
+							className="h-auto p-4 justify-start gap-4"
+							onClick={() => {
+								onOpenChange(false);
+								onConnectExisting?.();
+							}}
+						>
+							<div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center text-muted-foreground">
+								<Link2 className="h-5 w-5" />
+							</div>
+							<div className="flex flex-col items-start gap-1 text-left">
+								<span className="font-semibold">Connect to Existing</span>
+								<span className="text-xs text-muted-foreground">
+									Link to a node already in this dialogue
+								</span>
+							</div>
+						</Button>
 					</div>
-					<div className="flex flex-col items-start gap-1 text-left">
-						<span className="font-semibold">Connect to Existing</span>
-						<span className="text-xs text-muted-foreground">
-							Link to a node already in this dialogue
-						</span>
-					</div>
-				</Button>
-			</div>
-		</DialogContent>
-	</Dialog>
+				</div>
+
+				{/* Static footer with dismiss */}
+				<DrawerFooter className="border-t border-border/60 bg-background">
+					<Button variant="ghost" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+				</DrawerFooter>
+			</DrawerContent>
+		</Drawer>
 	);
 }

--- a/src/components/dialogue/NodeTypeSelectionModal.jsx
+++ b/src/components/dialogue/NodeTypeSelectionModal.jsx
@@ -1,4 +1,4 @@
-import { MessageCircle, User, CornerUpLeft, CheckCircle2, Clock, ExternalLink } from 'lucide-react';
+import { MessageCircle, User, CornerUpLeft, CheckCircle2, Clock, ExternalLink, Link2 } from 'lucide-react';
 import {
 	Dialog,
 	DialogContent,
@@ -13,7 +13,7 @@ import { getCreatableNodeDefinitions } from '@/config/dialogueNodes';
  * Node Type Selection Modal Component
  * Allows mobile users to select which type of node to create
  */
-export function NodeTypeSelectionModal({ open, onOpenChange, onSelectType }) {
+export function NodeTypeSelectionModal({ open, onOpenChange, onSelectType, onConnectExisting }) {
 	const iconMap = {
 		messageCircle: MessageCircle,
 		user: User,
@@ -61,8 +61,27 @@ export function NodeTypeSelectionModal({ open, onOpenChange, onSelectType }) {
 							</Button>
 						);
 					})}
-				</div>
-			</DialogContent>
-		</Dialog>
+				<div className="border-t border-border my-1" />
+				<Button
+					variant="outline"
+					className="h-auto p-4 justify-start gap-4"
+					onClick={() => {
+						onOpenChange(false);
+						onConnectExisting?.();
+					}}
+				>
+					<div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center text-muted-foreground">
+						<Link2 className="h-5 w-5" />
+					</div>
+					<div className="flex flex-col items-start gap-1 text-left">
+						<span className="font-semibold">Connect to Existing</span>
+						<span className="text-xs text-muted-foreground">
+							Link to a node already in this dialogue
+						</span>
+					</div>
+				</Button>
+			</div>
+		</DialogContent>
+	</Dialog>
 	);
 }

--- a/src/routes/projects/$projectId/dialogue/$dialogueId/index.jsx
+++ b/src/routes/projects/$projectId/dialogue/$dialogueId/index.jsx
@@ -101,6 +101,7 @@ import { SimpleTooltip } from '@/components/ui/tooltip';
 import { AppHeader } from '@/components/ui/app-header';
 import { LanguageSelector } from '@/components/ui/LanguageSelector';
 import { NodeTypeSelectionModal } from '@/components/dialogue/NodeTypeSelectionModal';
+import { NodeConnectionModal } from '@/components/dialogue/NodeConnectionModal';
 import { DialoguePreviewOverlay } from '@/components/dialogue/DialoguePreviewOverlay';
 import { getDeviceType } from '@/lib/deviceDetection';
 import { validatePreviewGraph } from '@/lib/dialoguePreviewEngine';
@@ -423,6 +424,8 @@ function DialogueEditorPage() {
 	const isDesktopElectron = isDesktopElectronRuntime();
 	const [isNodeTypeModalOpen, setIsNodeTypeModalOpen] = useState(false);
 	const [pendingPlaceholderData, setPendingPlaceholderData] = useState(null);
+	const [isNodeConnectionModalOpen, setIsNodeConnectionModalOpen] = useState(false);
+	const [connectionCandidateNodes, setConnectionCandidateNodes] = useState([]);
 	const [isMobilePanelOpen, setIsMobilePanelOpen] = useState(false);
 	const [isCascadeDeleteOpen, setIsCascadeDeleteOpen] = useState(false);
 	const [isEdgeCascadeDeleteOpen, setIsEdgeCascadeDeleteOpen] = useState(false);
@@ -1770,6 +1773,55 @@ function DialogueEditorPage() {
 		setPendingPlaceholderData({ placeholderId, position, parentNodeId });
 		setIsNodeTypeModalOpen(true);
 	}, []);
+
+	// Open the node connection drawer with valid candidate nodes (mobile)
+	const handleConnectExistingClicked = useCallback(() => {
+		if (!pendingPlaceholderData) return;
+		const { parentNodeId } = pendingPlaceholderData;
+
+		const alreadyConnected = new Set(
+			edges
+				.filter((e) => e.source === parentNodeId && !e.data?.isPlaceholder)
+				.map((e) => e.target)
+		);
+
+		const candidates = nodes.filter(
+			(n) =>
+				n.type !== 'placeholderNode' &&
+				n.id !== parentNodeId &&
+				n.id !== START_NODE_ID &&
+				!alreadyConnected.has(n.id)
+		);
+
+		setConnectionCandidateNodes(candidates);
+		setIsNodeTypeModalOpen(false);
+		setIsNodeConnectionModalOpen(true);
+	}, [pendingPlaceholderData, nodes, edges]);
+
+	// Connect parent node to an existing node, removing the placeholder (mobile)
+	const handleConnectExistingNode = useCallback((targetNodeId) => {
+		if (!pendingPlaceholderData) return;
+		const { placeholderId, parentNodeId } = pendingPlaceholderData;
+
+		setNodes((nds) => nds.filter((n) => n.id !== placeholderId));
+		setEdges((eds) => {
+			const withoutPlaceholder = eds.filter((e) => e.target !== placeholderId);
+			const newEdge = {
+				id: `${parentNodeId}-${targetNodeId}`,
+				source: parentNodeId,
+				target: targetNodeId,
+				type: 'conditionEdge',
+				markerEnd: { type: MarkerType.ArrowClosed },
+				data: { conditions: { mode: 'all', rules: [] } },
+			};
+			return addEdge(newEdge, withoutPlaceholder);
+		});
+
+		markUnsaved();
+		setIsNodeConnectionModalOpen(false);
+		setPendingPlaceholderData(null);
+		setConnectionCandidateNodes([]);
+	}, [pendingPlaceholderData, setNodes, setEdges, markUnsaved]);
 
 	// Handle node type selection from modal (mobile)
 	const handleNodeTypeSelect = useCallback((nodeType) => {
@@ -3147,6 +3199,15 @@ function DialogueEditorPage() {
 				open={isNodeTypeModalOpen}
 				onOpenChange={setIsNodeTypeModalOpen}
 				onSelectType={handleNodeTypeSelect}
+				onConnectExisting={handleConnectExistingClicked}
+			/>
+
+			{/* Node Connection Modal (Mobile) */}
+			<NodeConnectionModal
+				open={isNodeConnectionModalOpen}
+				onOpenChange={setIsNodeConnectionModalOpen}
+				candidateNodes={connectionCandidateNodes}
+				onSelectNode={handleConnectExistingNode}
 			/>
 
 			{showMobileGraphLoader &&

--- a/src/routes/projects/$projectId/dialogue/$dialogueId/index.jsx
+++ b/src/routes/projects/$projectId/dialogue/$dialogueId/index.jsx
@@ -1785,13 +1785,34 @@ function DialogueEditorPage() {
 				.map((e) => e.target)
 		);
 
-		const candidates = nodes.filter(
-			(n) =>
-				n.type !== 'placeholderNode' &&
-				n.id !== parentNodeId &&
-				n.id !== START_NODE_ID &&
-				!alreadyConnected.has(n.id)
-		);
+		// Build adjacency map for non-placeholder edges (target → sources that reach it)
+		// Used for cycle detection: a candidate would create a cycle if it can already
+		// reach parentNodeId through the existing graph (candidate → ... → parentNodeId).
+		const reachableFrom = (startId) => {
+			const visited = new Set();
+			const queue = [startId];
+			while (queue.length > 0) {
+				const cur = queue.shift();
+				if (visited.has(cur)) continue;
+				visited.add(cur);
+				edges
+					.filter((e) => e.source === cur && !e.data?.isPlaceholder)
+					.forEach((e) => queue.push(e.target));
+			}
+			return visited;
+		};
+
+		const candidates = nodes.filter((n) => {
+			if (n.type === 'placeholderNode') return false;
+			if (n.id === parentNodeId) return false;
+			if (n.id === START_NODE_ID) return false;
+			if (alreadyConnected.has(n.id)) return false;
+			// Exclude nodes that can already reach parentNodeId — connecting them
+			// would create a cycle.
+			const reachable = reachableFrom(n.id);
+			if (reachable.has(parentNodeId)) return false;
+			return true;
+		});
 
 		setConnectionCandidateNodes(candidates);
 		setIsNodeTypeModalOpen(false);


### PR DESCRIPTION
Hotfix for Node selector on Mobile/Tablet devices.
When selecting `Add Node` dummy on mobile:
- modal window replaced with drawer
- option `Connect Node` added
- - native select with all available nodes displayed

Attempt to disable circular connections, however, might not be perfect.